### PR TITLE
[statping-ui] : fix for downtime crop issue

### DIFF
--- a/react-frontend/src/components/GroupServiceFailures.jsx
+++ b/react-frontend/src/components/GroupServiceFailures.jsx
@@ -132,6 +132,21 @@ const GroupServiceFailures = ({ group = null, service, collapse }) => {
 
   if (loaded) return <ServiceLoader text="Loading series.." />;
 
+  const generateTooltipPosition = (...args) => {
+    const position = args?.[0]; //tooltip default position
+    const place = args?.[4]; // tooltip placement
+    const offset = 6;
+
+    if (place === "left" || place === "right") {
+      return {
+        top: position.top,
+        left:
+          place === "left" ? position.left + offset : position.left - offset,
+      };
+    }
+    return position;
+  };
+
   return (
     <div name="fade" style={{ display: collapse ? "none" : "block" }}>
       <div className="block-chart">
@@ -140,16 +155,18 @@ const GroupServiceFailures = ({ group = null, service, collapse }) => {
           place="bottom"
           backgroundColor="#344A6C"
           html={true}
+          overridePosition={generateTooltipPosition}
         />
         {failureData?.length > 0 ? (
           failureData.map((d, i) => {
             return (
               <div
-                className={`flex-fill service_day ${STATUS_CLASS[d.status]}`}
+                className={`service_day ${STATUS_CLASS[d.status]}`}
                 onMouseOver={() => handleMouseOver(d)}
                 onMouseOut={handleMouseOut}
                 key={i}
-                data-tip={hoverText}>
+                data-tip={hoverText}
+              >
                 {d.status !== 0 && (
                   <span className="d-none d-md-block text-center small"></span>
                 )}
@@ -166,13 +183,8 @@ const GroupServiceFailures = ({ group = null, service, collapse }) => {
         <div className="no-select">
           <p className="divided justify-content-between">
             <span className="timeline-text font-12">
-              90 {langs("days_ago")}
+              {langs("status_over_the_past")} 90 {langs("days")}
             </span>
-            {/* <span className="timeline-divider"></span> */}
-            {/* <span className="timeline-text font-12">{service_txt()}</span> */}
-            {/* <span className="timeline-text font-12">{uptime}% uptime</span> */}
-            <span className="timeline-divider"></span>
-            <span className="timeline-text font-12">{langs("today")}</span>
           </p>
         </div>
       </div>

--- a/react-frontend/src/components/GroupServiceFailures.jsx
+++ b/react-frontend/src/components/GroupServiceFailures.jsx
@@ -6,7 +6,11 @@ import API from "../config/API";
 import ServiceLoader from "./ServiceLoader";
 import ReactTooltip from "react-tooltip";
 import { STATUS_CLASS } from "../utils/constants";
-import { calcPer, isObjectEmpty } from "../utils/helper";
+import {
+  calcPer,
+  generateTooltipPosition,
+  isObjectEmpty,
+} from "../utils/helper";
 import { errorToastConfig } from "../utils/toast";
 
 const STATUS_TEXT = {
@@ -131,21 +135,6 @@ const GroupServiceFailures = ({ group = null, service, collapse }) => {
   const handleMouseOut = () => setHoverText("");
 
   if (loaded) return <ServiceLoader text="Loading series.." />;
-
-  const generateTooltipPosition = (...args) => {
-    const position = args?.[0]; //tooltip default position
-    const place = args?.[4]; // tooltip placement
-    const offset = 6;
-
-    if (place === "left" || place === "right") {
-      return {
-        top: position.top,
-        left:
-          place === "left" ? position.left + offset : position.left - offset,
-      };
-    }
-    return position;
-  };
 
   return (
     <div name="fade" style={{ display: collapse ? "none" : "block" }}>

--- a/react-frontend/src/config/langs.js
+++ b/react-frontend/src/config/langs.js
@@ -141,6 +141,7 @@ const english = {
   notify_all: "Notify All Changes",
   service_update: "Update Service",
   service_create: "Create Service",
+  status_over_the_past: "Status over the past",
 };
 
 const langs = (v) => english[v];

--- a/react-frontend/src/styles/scss/base.scss
+++ b/react-frontend/src/styles/scss/base.scss
@@ -131,11 +131,12 @@
 }
 
 .block-chart {
+  padding-top: 7px;
+  height: 100%;
   display: flex;
-  justify-content: center;
-  margin: 1rem 0;
-  padding: 0 0.75rem;
-
+  flex-flow: row wrap;
+  justify-content: flex-start;
+  gap: 1px;
   div.service_day:last-child {
     margin-right: 0;
   }
@@ -144,8 +145,9 @@
 .service_day {
   position: relative;
   height: 24px;
-  min-width: 4px;
-  margin-right: 2px;
+  min-width: 6px;
+  margin-right: 1.5px;
+  margin-bottom: 4px;
   cursor: pointer;
 }
 

--- a/react-frontend/src/styles/scss/variables.scss
+++ b/react-frontend/src/styles/scss/variables.scss
@@ -3,7 +3,7 @@ $background-color: #f5f8ff;
 $primary-bg: linear-gradient(314deg, #54a5ff -40%, #03299c);
 $container-color: #ffffff;
 $text-color: #2a2a2a;
-$max-width: 775px;
+$max-width: 824px;
 
 /* colors */
 $base-color: #1f2849;

--- a/react-frontend/src/utils/helper.js
+++ b/react-frontend/src/utils/helper.js
@@ -93,13 +93,14 @@ export const generateUUID = (length) => {
 
 export const generateTooltipPosition = (...args) => {
   const position = args?.[0]; //tooltip default position
+  const { top, left } = position;
   const place = args?.[4]; // tooltip placement
   const offset = 6;
 
   if (place === "left" || place === "right") {
     return {
-      top: position.top,
-      left: place === "left" ? position.left + offset : position.left - offset,
+      top: top,
+      left: place === "left" ? left + offset : left - offset,
     };
   }
   return position;

--- a/react-frontend/src/utils/helper.js
+++ b/react-frontend/src/utils/helper.js
@@ -90,3 +90,17 @@ export const generateUUID = (length) => {
     Math.floor(Math.random() * 36).toString(36)
   ).join("");
 };
+
+export const generateTooltipPosition = (...args) => {
+  const position = args?.[0]; //tooltip default position
+  const place = args?.[4]; // tooltip placement
+  const offset = 6;
+
+  if (place === "left" || place === "right") {
+    return {
+      top: position.top,
+      left: place === "left" ? position.left + offset : position.left - offset,
+    };
+  }
+  return position;
+};

--- a/react-frontend/src/utils/helper.js
+++ b/react-frontend/src/utils/helper.js
@@ -99,7 +99,7 @@ export const generateTooltipPosition = (...args) => {
 
   if (place === "left" || place === "right") {
     return {
-      top: top,
+      top,
       left: place === "left" ? left + offset : left - offset,
     };
   }

--- a/react-frontend/src/utils/helper.js
+++ b/react-frontend/src/utils/helper.js
@@ -93,7 +93,7 @@ export const generateUUID = (length) => {
 
 export const generateTooltipPosition = (...args) => {
   const position = args?.[0]; //tooltip default position
-  const { top, left } = position;
+  const { top, left } = position || {};
   const place = args?.[4]; // tooltip placement
   const offset = 6;
 


### PR DESCRIPTION
**What is the PR About ?** 

The PR contains fixes for the timeline component that shows downtime. Firstly, the component was getting cropped on mobile view. and the pop-over placement was wrong when the position is left/right.

**Slack thread :**  https://razorpay.slack.com/archives/C01J62JFFRT/p1672192583974919 

**Attachments :** 
<img width="451" alt="Screenshot 2023-01-10 at 2 18 08 PM" src="https://user-images.githubusercontent.com/108728818/211506418-e6a2b3a4-d64e-4b87-8d77-3956cdedd6d3.png">

<img width="356" alt="Screenshot 2023-01-10 at 2 18 20 PM" src="https://user-images.githubusercontent.com/108728818/211506463-6e34d9ce-d26f-4677-b7f7-3de95acf1bbf.png">

[Rzp Status Page .webm](https://user-images.githubusercontent.com/108728818/211506522-b5f523d2-5724-44e3-86f2-531689c80687.webm)


